### PR TITLE
Update M365SATTester.ps1 &  M365SAT.psm1

### DIFF
--- a/M365SAT.psm1
+++ b/M365SAT.psm1
@@ -133,7 +133,6 @@ function Get-M365SATReport
 	. $PSScriptRoot\core\Check-M365SATModuleDuplicates.ps1
 	. $PSScriptRoot\core\Check-M365SATModules.ps1
 	. $PSScriptRoot\core\Update-M365SATModules.ps1
-	. $PSScriptRoot\core\Check-M365SATUpdates.ps1
 	
 	# Import the PoShLog Module
 	Import-Module PoShLog

--- a/M365SATTester.ps1
+++ b/M365SATTester.ps1
@@ -13,8 +13,7 @@ function CheckAdminPrivBeta
 	$IsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 	if (-not $IsAdmin)
 	{
-		Write-Warning "[!] Program needs Administrator Rights! Trying to Elevate to Admin..."
-		Start-Process powershell -Verb runas -ArgumentList "-NoExit -c cd '$pwd'; .\M365SATTester.ps1"
+		Write-Warning "[!] Program needs Administrator Rights! Please reopen PowerShell with an elevated prompt..."
 	}
 	else
 	{


### PR DESCRIPTION
M365SATTESTER.PS1:
Removes Self-Elevation in the script. 
Self-Elevation is not considered secure and causes many security solutions to halt script operation.
Making security exceptions may not be an option if working in client environments.

M365SAT.PSM1:
Removes dot sourcing of Check-M365SATUPDATES.PS1

Both to address security concerns which cause the script to immediately be halted automatically.